### PR TITLE
Chore: virtual scroller typescript module 설치

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.202",
+    "@types/vue-virtual-scroller": "npm:@earltp/vue-virtual-scroller",
     "@typescript-eslint/parser": "^7.1.0",
     "lodash": "^4.17.21",
     "phaser": "^3.70.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -363,6 +363,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
+"@types/vue-virtual-scroller@npm:@earltp/vue-virtual-scroller":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@earltp/vue-virtual-scroller/-/vue-virtual-scroller-1.0.1.tgz#75116ef9b091457a654d92ff0688e991b3cd9e8a"
+  integrity sha512-7UsmP2JALnkfWlheuWRDywuBUTLJcVPE86X5ogA3djUmYFybE6qximgQ7OgyJnrKLteWR7+1Cp0GUXHhdDKaDQ==
+
 "@typescript-eslint/eslint-plugin@^6.4.0", "@typescript-eslint/eslint-plugin@^6.7.0":
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz#30830c1ca81fd5f3c2714e524c4303e0194f9cd3"


### PR DESCRIPTION
# virtual scroller typescript module 설치
## 수정사항
virtual scroller의 type을 정의하는 모듈을 설치했습니다. 설치하지 않으면 eslint 에러가 발생합니다.