### PR TITLE
플레이어끼리 충돌시 튕기지 않도록 수정

### DIFF
--- a/client/src/game/scenes/Game.ts
+++ b/client/src/game/scenes/Game.ts
@@ -143,9 +143,15 @@ export class Game extends Scene {
 
     const { direction, directionX, directionY } = getDirection(this.player.flipX, this.cursors);
     const { angle, shouldFlipX } = directionToAngleFlip(direction, this.player.flipX);
-    this.direction = direction;
-    this.player.setFlipX(shouldFlipX);
-    this.player.setAngle(angle);
+    if (this.direction !== direction) {
+      this.direction = direction;
+    }
+    if (this.player.flipX !== shouldFlipX) {
+      this.player.setFlipX(shouldFlipX);
+    }
+    if (this.player.angle !== angle) {
+      this.player.setAngle(angle);
+    }
 
     const isArrowKeyPressed =
       this.cursors.left.isDown || this.cursors.right.isDown || this.cursors.up.isDown || this.cursors.down.isDown;
@@ -244,10 +250,13 @@ export class Game extends Scene {
           targetPlayerSprite.x = player.centerX;
           targetPlayerSprite.y = player.centerY;
           const { angle, shouldFlipX } = directionToAngleFlip(player.direction, player.isFlipX ?? false);
-          targetPlayer.isFlipX = shouldFlipX;
-          targetPlayerSprite.setFlipX(shouldFlipX);
+          if (targetPlayerSprite.flipX !== shouldFlipX) {
+            targetPlayerSprite.setFlipX(shouldFlipX);
+          }
+          if (targetPlayerSprite.angle !== angle) {
+            targetPlayerSprite.setAngle(angle);
+          }
           targetPlayerSprite.updateNicknamePosition();
-          targetPlayerSprite.setAngle(angle);
         }
       }
     });

--- a/client/src/game/services/player/classes/playerSprite.ts
+++ b/client/src/game/services/player/classes/playerSprite.ts
@@ -6,8 +6,8 @@ export class PlayerSprite extends Phaser.Physics.Matter.Sprite {
   nicknameSprite: Phaser.GameObjects.Text;
   moveSpeed: number;
   shapes: {
-    default: string | Phaser.Types.Physics.Matter.MatterSetBodyConfig;
-    flipped: string | Phaser.Types.Physics.Matter.MatterSetBodyConfig;
+    default: Phaser.Types.Physics.Matter.MatterSetBodyConfig;
+    flipped: Phaser.Types.Physics.Matter.MatterSetBodyConfig;
   };
 
   constructor(world: Phaser.Physics.Matter.World, scene: Phaser.Scene, texture: string, player: Player) {
@@ -54,8 +54,7 @@ export class PlayerSprite extends Phaser.Physics.Matter.Sprite {
       // 바디 교체
       super.setFlipX(isFlipX);
       const bodyData = isFlipX ? this.shapes.flipped : this.shapes.default;
-      // this.setBody(bodyData);
-
+      this.setBody(bodyData);
       // 저장된 속도와 위치를 새 바디에 적용
       this.setVelocity(currentVelocity.x, currentVelocity.y);
       this.setPosition(currentPosition.x, currentPosition.y);


### PR DESCRIPTION
# 플레이어끼리 충돌시, 튕기지 않도록 수정

- 나 이외에 다른 플레이어들은 static으로 설정
- body의 vertices만 바꾸는 것은 추후 적용하는 것이 좋을 것 같음
- body를 너무 자주 변경하지 않도록 최적화
- 충돌시 약간의 bounce는 있도록 해야 연속적인 공격이 가능할 것 같음