### PR TITLE
고스트 플랑크톤 QA 이슈

### DIFF
--- a/client/src/game/components/PlayerStatus.vue
+++ b/client/src/game/components/PlayerStatus.vue
@@ -35,7 +35,9 @@ onMounted(() => {
       healthRef.value.style.width = `${playerStatusInfo.health}%`;
     }
 
-    // TODO: 체력 회복 UI
+    if (healthRef.value !== undefined && healthRef.value !== null) {
+      healthRef.value.style.width = `${playerStatusInfo.health}%`;
+    }
   });
 });
 </script>

--- a/client/src/game/scenes/Game.ts
+++ b/client/src/game/scenes/Game.ts
@@ -19,7 +19,6 @@ import crashService from "../services/player/feat/crash";
 import { SCENE } from "../constants/scene";
 import Swal from "sweetalert2";
 import type { SceneType } from "../types/scene";
-import { onTriggerPlanktonEat } from "../services/plankton/feat/eat";
 
 export class Game extends Scene {
   player: PlayerSprite;
@@ -156,7 +155,7 @@ export class Game extends Scene {
         }
         // 플랑크톤과 플레이어의 충돌
         else if (pair.bodyA.gameObject instanceof PlanktonGraphics && pair.bodyB.gameObject === this.player) {
-          onTriggerPlanktonEat(pair.bodyA.gameObject.plankton.planktonId);
+          this.eatPlankton(pair.bodyA.gameObject.plankton.planktonId, this.player.playerId);
         }
       });
     });
@@ -239,10 +238,6 @@ export class Game extends Scene {
         // 다른 플레이어들의 위치 동기화 신호 수신
         case "others-position-sync":
           this.onReceivedPositionSync(event.data as PlayerPositionInfo[]);
-          break;
-        // 내 플레이어가 플랑크톤 섭취
-        case "plankton-eat":
-          this.onReceivedPlanktonEat(event.data as number, this.player.playerId);
           break;
         // 다른 플레이어가 플랑크톤 섭취
         case "plankton-delete":
@@ -349,7 +344,7 @@ export class Game extends Scene {
     return true;
   }
 
-  onReceivedPlanktonEat(planktonId: number, playerId: number): void {
+  eatPlankton(planktonId: number, playerId: number): void {
     socket.emit(
       "plankton-eat",
       {
@@ -358,7 +353,7 @@ export class Game extends Scene {
       },
       (response: eatPlanktonResponse) => {
         if (response.isSuccess) {
-          this.planktonList.get(planktonId)?.hidden();
+          this.planktonList.get(planktonId)?.destroy();
           this.planktonList.delete(planktonId);
           g.planktonMap.delete(planktonId);
           this.sound.add("eat_plankton").play({ volume: 0.2 });
@@ -376,7 +371,7 @@ export class Game extends Scene {
   }
 
   onReceivedPlanktonDelete(planktonId: number): void {
-    this.planktonList.get(planktonId)?.hidden();
+    this.planktonList.get(planktonId)?.destroy();
     this.planktonList.delete(planktonId);
   }
 

--- a/client/src/game/services/plankton/classes/planktonGraphics.ts
+++ b/client/src/game/services/plankton/classes/planktonGraphics.ts
@@ -34,9 +34,4 @@ export class PlanktonGraphics extends Phaser.Physics.Matter.Sprite {
     super.destroy();
     this.graphics.destroy();
   }
-
-  hidden(): void {
-    this.setActive(false).setVisible(false);
-    this.graphics.setVisible(false);
-  }
 }

--- a/client/src/game/services/plankton/feat/eat.ts
+++ b/client/src/game/services/plankton/feat/eat.ts
@@ -1,8 +1,0 @@
-import g from "@/game/utils/global";
-
-export const onTriggerPlanktonEat = (planktonId: any): void => {
-  g.eventQueue.append({
-    key: "plankton-eat",
-    data: planktonId
-  });
-};


### PR DESCRIPTION
# 고스트 플랑크톤 QA 이슈
## QA 이슈
- 초기 입장 시 플랑크톤 초기화 
- 불필요한 플랑크톤 섭취 이벤트(eventQueue) 삭제 

## 추가 사항
- 변경된 소켓 명세서에 따라 plankton-eat 콜백 수정
- 플랑크톤 섭취 시 player-status-sync 이벤트를 송신하여 HP 회복