### PR TITLE
Refactor: 랭킹 위치수정 및 백만 단위(m) 적용

### DIFF
--- a/client/src/game/components/RankingPanel.vue
+++ b/client/src/game/components/RankingPanel.vue
@@ -32,6 +32,10 @@ onUpdated(() => {
     }
   });
 });
+
+const formatTotalExp = (totalExp: number): string | number => {
+  return totalExp >= 1000000 ? `${Math.floor(totalExp / 100000) / 10}m` : totalExp;
+};
 </script>
 
 <template>
@@ -60,7 +64,7 @@ onUpdated(() => {
             <td class="overflow-hidden">
               <div ref="textEllipsisRef" class="ranking-speciesname">{{ ranking.speciesname }}</div>
             </td>
-            <td class="ranking-total-exp">{{ ranking.totalExp }}</td>
+            <td class="ranking-total-exp">{{ formatTotalExp(ranking.totalExp) }}</td>
           </tr>
         </tbody>
       </table>
@@ -74,7 +78,7 @@ onUpdated(() => {
   width: 100%;
   background-color: var(--transparent-black);
   position: absolute;
-  right: 1rem;
+  left: 1rem;
   top: 1rem;
   padding: 10px;
   border-radius: 10px;


### PR DESCRIPTION
# 랭킹 위치수정 및 백만 단위(m) 적용
## 수정 사항
- 랭킹패널의 위치를 좌측으로 수정했습니다.
- 누적경험치(totalExp) 1백만 이상부터는 채팅 UI가 깨지므로, m단위를 적용했습니다.

![랭킹수정1](https://github.com/lost-marine/lost-marine-client/assets/39663810/55bde514-50eb-48e3-8520-c7d4647f4bfe)
